### PR TITLE
Remove audit and add python check

### DIFF
--- a/src/commands/upload_package_using_cli.yml
+++ b/src/commands/upload_package_using_cli.yml
@@ -15,21 +15,27 @@ steps:
       command: <<include(scripts/configure_cloudsmith_defaults.sh)>>
   - cloudsmith-oidc/authenticate_with_oidc
   - run:
-      name: Install python3 and pip
-      command: |
+    name: Check and install python3 and pip
+    command: |
+      if ! command -v pip3 &> /dev/null
+      then
+        echo "pip3 is not installed. Installing now..."
         sudo apt-get update
         sudo apt-get install -y python3-pip
+      else
+        echo "pip3 is already installed. Skipping installation."
+      fi
   - run:
-      name: Cloudsmith - Install CLI
-      command: |
-        echo "Installing cloudsmith-cli using pip ..."
+    name: Cloudsmith - Install CLI
+    command: |
+      echo "Installing cloudsmith-cli using pip ..."
 
-        python -m pip install cloudsmith-cli --upgrade --user --extra-index-url=https://dl.cloudsmith.io/public/cloudsmith/cli/python/index/
+      python -m pip install cloudsmith-cli --upgrade --user --extra-index-url=https://dl.cloudsmith.io/public/cloudsmith/cli/python/index/
 
-        echo ""
-        echo "Cloudsmith CLI installed OK."
+      echo ""
+      echo "Cloudsmith CLI installed OK."
 
-        cloudsmith --version
+      cloudsmith --version
   - run:
       name: Cloudsmith - Upload npm package file(s)
       command: <<include(scripts/upload_package_using_cli.sh)>>

--- a/src/commands/upload_package_using_cli.yml
+++ b/src/commands/upload_package_using_cli.yml
@@ -15,27 +15,27 @@ steps:
       command: <<include(scripts/configure_cloudsmith_defaults.sh)>>
   - cloudsmith-oidc/authenticate_with_oidc
   - run:
-    name: Check and install python3 and pip
-    command: |
-      if ! command -v pip3 &> /dev/null
-      then
-        echo "pip3 is not installed. Installing now..."
-        sudo apt-get update
-        sudo apt-get install -y python3-pip
-      else
-        echo "pip3 is already installed. Skipping installation."
-      fi
+      name: Check and install python3 and pip
+      command: |
+        if ! command -v pip3 &> /dev/null
+        then
+          echo "pip3 is not installed. Installing now..."
+          sudo apt-get update
+          sudo apt-get install -y python3-pip
+        else
+          echo "pip3 is already installed. Skipping installation."
+        fi
   - run:
-    name: Cloudsmith - Install CLI
-    command: |
-      echo "Installing cloudsmith-cli using pip ..."
+      name: Cloudsmith - Install CLI
+      command: |
+        echo "Installing cloudsmith-cli using pip ..."
 
-      python -m pip install cloudsmith-cli --upgrade --user --extra-index-url=https://dl.cloudsmith.io/public/cloudsmith/cli/python/index/
+        python -m pip install cloudsmith-cli --upgrade --user --extra-index-url=https://dl.cloudsmith.io/public/cloudsmith/cli/python/index/
 
-      echo ""
-      echo "Cloudsmith CLI installed OK."
+        echo ""
+        echo "Cloudsmith CLI installed OK."
 
-      cloudsmith --version
+        cloudsmith --version
   - run:
       name: Cloudsmith - Upload npm package file(s)
       command: <<include(scripts/upload_package_using_cli.sh)>>

--- a/src/scripts/configure_npm.sh
+++ b/src/scripts/configure_npm.sh
@@ -16,7 +16,8 @@ then
   exit 1
 fi
 
-npm config set audit false registry="$CLOUDSMITH_NPM_REGISTRY"
-npm config set audit false "$CLOUDSMITH_NPM_AUTH_CONFIG"
+npm config set registry="$CLOUDSMITH_NPM_REGISTRY"
+npm config set "$CLOUDSMITH_NPM_AUTH_CONFIG"
+npm config set audit false
 
 echo "NPM has been configured to use Cloudsmith registry with $CLOUDSMITH_NPM_REGISTRY."

--- a/src/scripts/configure_npm.sh
+++ b/src/scripts/configure_npm.sh
@@ -16,7 +16,7 @@ then
   exit 1
 fi
 
-npm config set registry="$CLOUDSMITH_NPM_REGISTRY"
-npm config set "$CLOUDSMITH_NPM_AUTH_CONFIG"
+npm config set audit false registry="$CLOUDSMITH_NPM_REGISTRY"
+npm config set audit false "$CLOUDSMITH_NPM_AUTH_CONFIG"
 
 echo "NPM has been configured to use Cloudsmith registry with $CLOUDSMITH_NPM_REGISTRY."


### PR DESCRIPTION
## Why?

 - We want to check if Pip is installed before attempted to install it to avoid conflicts
 - We also want to ensure that we're not attempting to do an NPM Audit when installing a package, to avoid polluting our logs.
