### PR TITLE
add check for npm install in configure-npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Cloudsmith NPM Orb
 
-
 A CircleCI orb to assist with downloading npm packages from and publishing npm packages to Cloudsmith.
 
 ---
@@ -14,12 +13,12 @@ The orb commands require the following environment variables to be set:
 
 These are used to authenticate with Cloudsmith using OIDC and can be found in the [Cloudsmith UI](https://cloudsmith.io/).
 
-
 ---
 
 ## Documentation
 
+[Main orb documentation page](https://circleci.com/developer/orbs/orb/ft-circleci-orbs/cloudsmith-npm)
 
+You can also find more information on how to use this orb in our [tech-hub guide.](https://tech.in.ft.com/tech-topics/development-tools/package-management/cloudsmith/set-up-circleci-node-projects-to-use-cloudsmith)
 
 ---
-

--- a/src/scripts/configure_npm.sh
+++ b/src/scripts/configure_npm.sh
@@ -5,6 +5,13 @@
 
 set +e
 
+# Check if npm is installed
+if ! command -v npm &> /dev/null
+then
+  echo "npm is not installed. Please install npm before running this script."
+  exit 1
+fi
+
 if [ -z "$CLOUDSMITH_NPM_REGISTRY" ]
 then
   echo "Unable to configure NPM. Env var CLOUDSMITH_NPM_REGISTRY is not defined. Please run the set_env_vars_for_npm command first."


### PR DESCRIPTION
## Why?

We previously weren't checking if npm was installed in the configure-npm script - this can cause the script to silently fail whilst still passing tests.

## What?

Added a check to see if npm is installed.
